### PR TITLE
Skeleton loading on event page

### DIFF
--- a/components/Event/EventLoading.tsx
+++ b/components/Event/EventLoading.tsx
@@ -4,24 +4,12 @@ export default function EventLoading() {
   return (
     <Box>
       <Stack direction="row" spacing={2}>
-        <Box className="skeletonLoading" w="95px" h="18px" rounded="lg"></Box>
-        <Box className="skeletonLoading" w="95px" h="18px" rounded="lg"></Box>
+        <Box className="skeletonLoading" w="95px" h="18px" rounded="lg" />
+        <Box className="skeletonLoading" w="95px" h="18px" rounded="lg" />
       </Stack>
 
-      <Box
-        className="skeletonLoading"
-        maxW="sm"
-        h="32px"
-        mt="7"
-        rounded="md"
-      ></Box>
-      <Box
-        className="skeletonLoading"
-        w="120px"
-        h="20px"
-        mt="2"
-        rounded="md"
-      ></Box>
+      <Box className="skeletonLoading" maxW="sm" h="32px" mt="7" rounded="md" />
+      <Box className="skeletonLoading" w="120px" h="20px" mt="2" rounded="md" />
 
       <Box
         className="skeletonLoading"
@@ -29,19 +17,19 @@ export default function EventLoading() {
         h="17px"
         mt="3"
         rounded="md"
-      ></Box>
+      />
       <Box
         className="skeletonLoading"
         maxW="57%"
         h="17px"
         mt="1"
         rounded="md"
-      ></Box>
+      />
 
       <Stack direction="row" spacing={2} justifyContent="flex-end" mt="5">
-        <Box className="skeletonLoading" w="85px" h="28px" rounded="lg"></Box>
-        <Box className="skeletonLoading" w="85px" h="28px" rounded="lg"></Box>
+        <Box className="skeletonLoading" w="85px" h="28px" rounded="lg" />
+        <Box className="skeletonLoading" w="85px" h="28px" rounded="lg" />
       </Stack>
     </Box>
-  );
+  )
 }

--- a/components/Event/EventLoading.tsx
+++ b/components/Event/EventLoading.tsx
@@ -1,4 +1,6 @@
 import { Box, Stack } from "@chakra-ui/react";
+import styles from "../../styles/eventId.module.css"
+import ParticipantUserLoading from "../ParticipantUserLoading"
 
 export default function EventLoading() {
   return (
@@ -30,6 +32,39 @@ export default function EventLoading() {
         <Box className="skeletonLoading" w="85px" h="28px" rounded="lg" />
         <Box className="skeletonLoading" w="85px" h="28px" rounded="lg" />
       </Stack>
+
+      <div className={styles.participantsPanel}>
+        <Box>
+          <Box
+            className="skeletonLoading"
+            w="105px"
+            h="21px"
+            mb="5"
+            rounded="lg"
+          />
+
+          <Stack direction="column" spacing={5}>
+            <ParticipantUserLoading />
+          </Stack>
+        </Box>
+
+        <Box>
+          <Box
+            className="skeletonLoading"
+            w="115px"
+            h="21px"
+            mb="5"
+            rounded="lg"
+          />
+
+          <Stack direction="column" spacing={5}>
+            <ParticipantUserLoading />
+            <ParticipantUserLoading />
+            <ParticipantUserLoading />
+            <ParticipantUserLoading />
+          </Stack>
+        </Box>
+      </div>
     </Box>
   )
 }

--- a/components/Event/EventSidebarLoading.tsx
+++ b/components/Event/EventSidebarLoading.tsx
@@ -1,0 +1,29 @@
+import { Box, Flex } from "@chakra-ui/react"
+import { WishlistLoadingItem } from "../WishlistItem"
+
+function EventSidebarLoading() {
+  return (
+    <>
+      <Flex mb="5" direction="row" alignItems="center" justifyContent="start">
+        <Box
+          className="skeletonLoading"
+          w="111px"
+          h="24px"
+          mb="5"
+          rounded="lg"
+          mt="1.5"
+        />
+      </Flex>
+
+      <Box overflow="hidden">
+        {[1, 2].map((p, i) => (
+          <Box mb="5" key={`loading#${i}`}>
+            <WishlistLoadingItem />
+          </Box>
+        ))}
+      </Box>
+    </>
+  )
+}
+
+export default EventSidebarLoading

--- a/components/ParticipantUserLoading.tsx
+++ b/components/ParticipantUserLoading.tsx
@@ -1,0 +1,32 @@
+import { Box, Stack } from "@chakra-ui/react"
+
+export default function ParticipantUserLoading() {
+  const avatarSize = "50px"
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2}>
+        <Box>
+          <Box
+            w={avatarSize}
+            h={avatarSize}
+            rounded="md"
+            className="skeletonLoading"
+          />
+        </Box>
+
+        <Box overflow="hidden" pr="2">
+          <Box className="skeletonLoading" w="90px" h="16px" rounded="md" />
+
+          <Box
+            className="skeletonLoading"
+            w="126px"
+            h="13px"
+            mt="1"
+            rounded="md"
+          />
+        </Box>
+      </Stack>
+    </Box>
+  )
+}

--- a/pages/events/[eventId]/[eventName].tsx
+++ b/pages/events/[eventId]/[eventName].tsx
@@ -6,19 +6,20 @@ import { IEventFull } from "../../../types/Event";
 import { NextRouter, useRouter } from "next/router";
 import { api } from "../../../util/api";
 import axios from "axios";
-import { Container, Icon } from "@chakra-ui/react";
-import { AuthState } from "../../../store/jwt-payload";
-import Event from "../../../components/Event/Event";
-import { BsExclamationCircle } from "react-icons/bs";
-import ErrorBlock from "../../../components/ErrorBlock";
-import EventContainer from "../../../components/Event/EventContainer";
-import EventLoading from "../../../components/Event/EventLoading";
-import { IParticipantUser } from "../../../types/Participant";
-import { IDrawParticipant } from "../../../types/Draw";
-import MyWishlist from "../../../components/MyWishlist";
-import EventSidebarMedium from "../../../components/Event/EventSidebarMedium";
-import { unstable_batchedUpdates } from "react-dom";
+import { Container, Icon } from "@chakra-ui/react"
+import { AuthState } from "../../../store/jwt-payload"
+import Event from "../../../components/Event/Event"
+import { BsExclamationCircle } from "react-icons/bs"
+import ErrorBlock from "../../../components/ErrorBlock"
+import EventContainer from "../../../components/Event/EventContainer"
+import EventLoading from "../../../components/Event/EventLoading"
+import { IParticipantUser } from "../../../types/Participant"
+import { IDrawParticipant } from "../../../types/Draw"
+import MyWishlist from "../../../components/MyWishlist"
+import EventSidebarMedium from "../../../components/Event/EventSidebarMedium"
+import { unstable_batchedUpdates } from "react-dom"
 import { eventNameSlug } from "../../../util/links"
+import EventSidebarLoading from "../../../components/Event/EventSidebarLoading"
 
 export default function EventPage() {
   const [loading, setLoading] = useState(true) // Loading state for the event page
@@ -71,7 +72,12 @@ export default function EventPage() {
 
   const renderEventBlock = () => {
     if (loading) {
-      return <EventContainer primary={<EventLoading />} />
+      return (
+        <EventContainer
+          primary={<EventLoading />}
+          sidebar={<EventSidebarLoading />}
+        />
+      )
     } else if (event && meParticipant) {
       return (
         <EventContainer


### PR DESCRIPTION
The event page skeleton loading looks very empty, with only the main event info panel skeleton. This pull request will also show the participant and organizer columns, and also render a skeleton for the sidebar.